### PR TITLE
Fixed an issue causing GProxy Extended players to get stuck in "Waiting for Host" screen when the game ends

### DIFF
--- a/game_base.cpp
+++ b/game_base.cpp
@@ -1459,7 +1459,11 @@ bool CBaseGame :: Update( void *fd, void *send_fd )
 		}
 
 		// see if we can handle any pending reconnects
-		if( !m_GHost->m_PendingReconnects.empty( ) && GetTicks( ) - m_LastReconnectHandleTime > 500 )
+		
+		// changed by h3rmit
+		// we shouldn't try to reconnect players after the gameover timer has started
+		
+		if( m_GameOverTime == 0 && !m_GHost->m_PendingReconnects.empty( ) && GetTicks( ) - m_LastReconnectHandleTime > 500 )
 		{
 			m_LastReconnectHandleTime = GetTicks( );
 


### PR DESCRIPTION
Fixed an issue causing GProxy Extended users to get stuck in a "Waiting for Host" screen when the game ends. The game no longer tries to reconnect players after the gameover timer has started. This allows GProxy clients to receive a GPS_REJECT message and stop trying to reconnect. 

Previously, all GProxy clients were getting engaged in an infinite disconnect/reconnect loop until the allowed reconnection time expired, or the player manually pressed the "Disconnect" button in the "Waiting for Host" screen. 

Note: Players using GProxy Extended cannot press the "Disconnect" button until the allowed reconnection time expires, in order to avoid accidental voluntary leaves.